### PR TITLE
Pattern match instead of map lookups

### DIFF
--- a/bench/to_gsm.exs
+++ b/bench/to_gsm.exs
@@ -1,0 +1,10 @@
+Mix.install([:benchee, {:gsm, path: "."}])
+
+Benchee.run(%{to_gsm: fn input -> GSM.to_gsm(input) end},
+  load: ["bench/pattern-match.benchee"],
+  save: [path: "bench/v0.1.1.benchee", tag: "v0.1.1"],
+  inputs: %{
+    extended: String.duplicate("{", 2048),
+    non_extended: String.duplicate("a", 2048)
+  }
+)


### PR DESCRIPTION
Speedup lookup and conversion by generating function heads for the mappings.

Boosts speed by about 70%.

```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
Number of Available Cores: 12
Available memory: 16 GB
Elixir 1.12.3
Erlang 24.1.7

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: extended, non_extended
Estimated total run time: 14 s

Benchmarking to_gsm with input extended ...
Benchmarking to_gsm with input non_extended ...

##### With input extended #####
Name                             ips        average  deviation         median         99th %
to_gsm (pattern-match)        6.53 K      153.23 μs    ±34.78%         133 μs         348 μs
to_gsm                        3.91 K      255.69 μs    ±34.74%         218 μs         549 μs

Comparison: 
to_gsm (pattern-match)        6.53 K
to_gsm                        3.91 K - 1.67x slower +102.46 μs

##### With input non_extended #####
Name                             ips        average  deviation         median         99th %
to_gsm (pattern-match)        6.63 K      150.83 μs    ±35.05%         131 μs      359.22 μs
to_gsm                        3.85 K      259.60 μs    ±33.71%         220 μs         549 μs

Comparison: 
to_gsm (pattern-match)        6.63 K
to_gsm                        3.85 K - 1.72x slower +108.77 μs
```